### PR TITLE
Project detail pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { Route, Switch } from 'react-router-dom'
 import { v4 as uuidv4 } from 'uuid'
 import AddNewProjectTab from './components/AddNewProjectTab'
 import FabricCalculatorTab from './components/FabricCalculatorTab'
+import ProjectDetailsTab from './components/ProjectDetailsTab'
 import ProjectList from './components/ProjectList'
 import ShoppingList from './components/ShoppingList'
 import {
@@ -26,11 +27,14 @@ export default function App() {
       <Route path="/shopping-list">
         <ShoppingList projectList={projectList} />
       </Route>
-      <Route path="/projects">
+      <Route exact path="/projects">
         <ProjectList
           projectList={projectList}
           updateProjectData={updateProjectData}
         />
+      </Route>
+      <Route path="/projects/:projectName">
+        <ProjectDetailsTab projectList={projectList} />
       </Route>
       <Route path="/add-new-project">
         <AddNewProjectTab onSubmit={addToProjectList} />

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,10 @@ export default function App() {
         />
       </Route>
       <Route path="/projects/:projectName/:id">
-        <ProjectDetailsTab projectList={projectList} />
+        <ProjectDetailsTab
+          projectList={projectList}
+          updateProjectData={updateProjectData}
+        />
       </Route>
       <Route path="/add-new-project">
         <AddNewProjectTab onSubmit={addToProjectList} />

--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ export default function App() {
           updateProjectData={updateProjectData}
         />
       </Route>
-      <Route path="/projects/:projectName">
+      <Route path="/projects/:projectName/:id">
         <ProjectDetailsTab projectList={projectList} />
       </Route>
       <Route path="/add-new-project">

--- a/src/App.js
+++ b/src/App.js
@@ -15,9 +15,13 @@ import WelcomeScreen from './components/WelcomeScreen.js'
 export default function App() {
   const [projectList, setProjectList] = useState([])
 
-  useEffect(() => setProjectList(getFromLocalStorage('projects') || []), [])
+  useEffect(() => {
+    setProjectList(getFromLocalStorage('projects') || [])
+  }, [])
 
-  useEffect(() => saveToLocalStorage('projects', projectList), [projectList])
+  useEffect(() => {
+    saveToLocalStorage('projects', projectList)
+  }, [projectList])
 
   return (
     <Switch>
@@ -28,10 +32,7 @@ export default function App() {
         <ShoppingList projectList={projectList} />
       </Route>
       <Route exact path="/projects">
-        <ProjectList
-          projectList={projectList}
-          updateProjectData={updateProjectData}
-        />
+        <ProjectList projectList={projectList} />
       </Route>
       <Route path="/projects/:projectName/:id">
         <ProjectDetailsTab

--- a/src/App.js
+++ b/src/App.js
@@ -1,27 +1,16 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { Route, Switch } from 'react-router-dom'
 import { v4 as uuidv4 } from 'uuid'
 import AddNewProjectTab from './components/AddNewProjectTab'
 import FabricCalculatorTab from './components/FabricCalculatorTab'
+import { useLocalStorageState } from './components/hooks/useLocalStorageState'
 import ProjectDetailsTab from './components/ProjectDetailsTab'
 import ProjectList from './components/ProjectList'
 import ShoppingList from './components/ShoppingList'
-import {
-  getFromLocalStorage,
-  saveToLocalStorage,
-} from './components/utils/handleLocalStorage'
 import WelcomeScreen from './components/WelcomeScreen.js'
 
 export default function App() {
-  const [projectList, setProjectList] = useState([])
-
-  useEffect(() => {
-    setProjectList(getFromLocalStorage('projects') || [])
-  }, [])
-
-  useEffect(() => {
-    saveToLocalStorage('projects', projectList)
-  }, [projectList])
+  const [projectList, setProjectList] = useLocalStorageState('projects')
 
   return (
     <Switch>

--- a/src/assets/arrowLeft.svg
+++ b/src/assets/arrowLeft.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="22px" height="47px" viewBox="0 0 22 47" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>arrowLeft</title>
+    <g id="UX-Design" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <g id="Artboard" transform="translate(-393.000000, -320.000000)" stroke="#3C9181" stroke-width="4">
+            <g id="Group" transform="translate(395.000000, 322.000000)">
+                <g id="Group" transform="translate(9.000000, 21.500000) scale(-1, 1) translate(-9.000000, -21.500000) ">
+                    <line x1="18" y1="22" x2="1" y2="43" id="Line-3"></line>
+                    <line x1="18" y1="22" x2="0" y2="0" id="Line-3"></line>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/assets/arrowRight.svg
+++ b/src/assets/arrowRight.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="22px" height="47px" viewBox="0 0 22 47" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>arrowRight</title>
+    <g id="UX-Design" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <g id="Artboard" transform="translate(-393.000000, -255.000000)" stroke="#3C9181" stroke-width="4">
+            <g id="Line-3" transform="translate(395.000000, 257.000000)">
+                <line x1="18" y1="22" x2="1" y2="43"></line>
+                <line x1="18" y1="22" x2="0" y2="0"></line>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/AddNewProjectForm.js
+++ b/src/components/AddNewProjectForm.js
@@ -29,7 +29,7 @@ export default function AddNewProjectForm({ addToProjectList }) {
 
         <InputField
           labelText="What's the next step?"
-          placeholderText="e.g. buy materials, cut fabric, sew..."
+          placeholderText="e.g. buy materials, cut fabric, sew ..."
           name="nextStep"
           registerFn={register}
           error={errors.nextStep}
@@ -60,20 +60,20 @@ export default function AddNewProjectForm({ addToProjectList }) {
 
         <InputTextarea
           labelText="Materials I have:"
-          placeholderText="separate materials with a comma."
+          placeholderText="separate materials with a comma"
           name="materialNeeds"
           registerFn={register}
           error={errors.materialNeeds}
-          errorMessageMax="The text is too long...?"
+          errorMessageMax="The text is too long ...?"
         />
 
         <InputTextarea
           labelText="Materials I need:"
-          placeholderText="separate materials with a comma."
+          placeholderText="separate materials with a comma"
           name="materialsExisting"
           registerFn={register}
           error={errors.materialsExisting}
-          errorMessageMax="Do you really need that much...?"
+          errorMessageMax="Do you really need that much ...?"
         />
       </StyledInputGroup>
 
@@ -86,8 +86,9 @@ const StyledForm = styled.form`
   display: flex;
   flex-flow: column;
   gap: 10px;
-  margin: 24px auto 74px auto;
-  font-weight: 200;
+  height: 446px;
+  overflow: scroll;
+  margin: 24px auto 50px auto;
 
   p {
     color: var(--teal-ultralight);
@@ -98,6 +99,10 @@ const StyledForm = styled.form`
 
   .optional {
     margin: 10px 0 -8px 10px;
+  }
+
+  button {
+    padding-bottom: 14px;
   }
 `
 const StyledInputGroup = styled.div`

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -12,9 +12,11 @@ export default function Button({
   return (
     <StyledButton width={size} onClick={onClick}>
       <img width={size} src={icon} alt={altText || ''} />
-      <p className="buttonText" fontSize={fontsize}>
-        {text}
-      </p>
+      {text && (
+        <p className="buttonText" fontSize={fontsize}>
+          {text}
+        </p>
+      )}
     </StyledButton>
   )
 }

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,10 +1,20 @@
 import React from 'react'
 import styled from 'styled-components'
 
-export default function Button({ icon, size, onClick, altText }) {
+export default function Button({
+  icon,
+  size,
+  onClick,
+  altText,
+  text,
+  fontsize,
+}) {
   return (
     <StyledButton width={size} onClick={onClick}>
       <img width={size} src={icon} alt={altText || ''} />
+      <p className="buttonText" fontSize={fontsize}>
+        {text}
+      </p>
     </StyledButton>
   )
 }
@@ -14,6 +24,7 @@ const StyledButton = styled.button`
   height: auto;
   width: ${(props) => props.width || '40px'};
   margin: auto;
+  text-align: center;
 
   :active {
     transform: scale(0.95, 0.95);
@@ -21,5 +32,9 @@ const StyledButton = styled.button`
 
   img {
     width: ${(props) => props.width || '40px'};
+  }
+
+  .buttonText {
+    font-size: ${(props) => props.fontSize || '10px'};
   }
 `

--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -38,6 +38,7 @@ export default function InputField({
 const StyledLabel = styled.label`
   color: var(--teal-medium);
   font-size: 18px;
+  font-weight: 200;
 
   input {
     width: 275px;

--- a/src/components/InputTextarea.js
+++ b/src/components/InputTextarea.js
@@ -31,6 +31,7 @@ export default function InputTextarea({
 const StyledLabel = styled.label`
   color: var(--teal-medium);
   font-size: 18px;
+  font-weight: 200;
 
   textarea {
     width: 275px;

--- a/src/components/ProjectDetailsTab.js
+++ b/src/components/ProjectDetailsTab.js
@@ -7,20 +7,34 @@ import NavigationBar from './NavigationBar'
 
 export default function ProjectDetailsTab({ projectList }) {
   const { id } = useParams()
-  const projectData = () => projectList.find((project) => id === project.id)
-  console.log(projectData)
-  // console.log(projectData.projectName)
+  const {
+    projectName,
+    pattern,
+    size,
+    nextStep,
+    materialNeeds,
+    materialsExisting,
+  } = projectList.find((project) => id === project.id)
+  console.log(projectName)
+  // const {
+  //   projectName,
+  //   pattern,
+  //   size,
+  //   nextStep,
+  //   materialNeeds,
+  //   materialsExisting,
+  // } = projectData
 
   return (
     <>
       <LogoHeader />
       <StyledTab>
-        <Headline
-          headlineText={'Project details'}
-          textColor={'var(--teal-medium)'}
-        />
-        <p>nüscht</p>
-        {/* <p>{projectData.projectName}</p> */}
+        <Headline headlineText={projectName} textColor={'var(--teal-medium)'} />
+        <p>{pattern}</p>
+        <p>{size}</p>
+        <p>{nextStep}</p>
+        <p>{materialNeeds}</p>
+        <p>{materialsExisting}</p>
       </StyledTab>
       <NavigationBar />
     </>

--- a/src/components/ProjectDetailsTab.js
+++ b/src/components/ProjectDetailsTab.js
@@ -1,7 +1,8 @@
 import React, { useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 import editIcon from '../assets/editIcon.svg'
+import arrowLeft from '../assets/arrowLeft.svg'
 import Button from './Button'
 import Headline from './Headline'
 import LogoHeader from './LogoHeader'
@@ -11,6 +12,7 @@ import ProjectUpdateForm from './ProjectUpdateForm'
 export default function ProjectDetailsTab({ projectList, updateProjectData }) {
   const [isEditing, setEditing] = useState(false)
   const { id } = useParams()
+  const history = useHistory()
   const projectData = projectList.find((project) => id === project.id)
   const {
     projectName,
@@ -26,6 +28,12 @@ export default function ProjectDetailsTab({ projectList, updateProjectData }) {
       <LogoHeader />
       <StyledTab>
         <Headline headlineText={projectName} textColor={'var(--teal-medium)'} />
+        <Button
+          className="back-button"
+          size="11px"
+          icon={arrowLeft}
+          onClick={() => history.push('/projects')}
+        />
         <StyledProject>
           {isEditing ? (
             <>
@@ -36,41 +44,42 @@ export default function ProjectDetailsTab({ projectList, updateProjectData }) {
               />
             </>
           ) : (
-            <div>
+            <>
               <Button
+                className="edit-button"
                 text="Edit"
                 size="30px"
                 icon={editIcon}
                 onClick={() => setEditing(true)}
               />
-              <p name="title">Next step:</p>
-              <p name="nextStep">{nextStep}</p>
+              <p className="title">Next step:</p>
+              <p className="entry">{nextStep}</p>
 
               {pattern && (
                 <>
-                  <p name="title">Pattern:</p>
-                  <p name="pattern">{pattern}</p>
+                  <p className="title">Pattern:</p>
+                  <p className="entry">{pattern}</p>
                 </>
               )}
               {size && (
                 <>
-                  <p name="title">Size:</p>
-                  <p name="size">{size}</p>
+                  <p className="title">Size:</p>
+                  <p className="entry">{size}</p>
                 </>
               )}
               {materialNeeds && (
                 <>
-                  <p name="title">Materials I need:</p>
-                  <p name="materials">{materialNeeds}</p>
+                  <p className="title">Materials I need:</p>
+                  <p className="entry">{materialNeeds}</p>
                 </>
               )}
               {materialsExisting && (
                 <>
-                  <p name="title">Materials I have:</p>
-                  <p name="materials">{materialsExisting}</p>
+                  <p className="title">Materials I have:</p>
+                  <p className="entry">{materialsExisting}</p>
                 </>
               )}
-            </div>
+            </>
           )}
         </StyledProject>
       </StyledTab>
@@ -80,6 +89,7 @@ export default function ProjectDetailsTab({ projectList, updateProjectData }) {
 }
 
 const StyledTab = styled.main`
+  position: relative;
   display: flex;
   flex-flow: column;
   align-items: center;
@@ -89,9 +99,10 @@ const StyledTab = styled.main`
   border-radius: 20px 20px 0 0;
   box-shadow: 0 -1px 3px -1px rgba(0, 0, 0, 0.3);
 
-  p {
-    color: var(--teal-medium);
-    font-size: 16px;
+  > button {
+    position: absolute;
+    top: 22px;
+    left: 20px;
   }
 `
 const StyledProject = styled.div`
@@ -103,32 +114,22 @@ const StyledProject = styled.div`
 
   button {
     position: absolute;
-    top: -16px;
+    top: -6px;
     right: -16px;
   }
 
   p {
     font-weight: 200;
+    font-size: 16px;
+  }
+  .title {
+    margin: 20px 0 6px 6px;
+    color: var(--teal-dark);
+    font-size: 18px;
+  }
+  .entry {
+    margin: 0 24px 0 24px;
     color: var(--teal-light);
     font-size: 16px;
-
-    &[name='projectName'] {
-      padding: 12px 24px 10px 24px;
-      color: var(--teal-dark);
-      font-size: 20px;
-    }
-
-    &[name='title'] {
-      margin-top: 10px;
-      color: var(--teal-medium);
-    }
-
-    &[name='nextStep'] {
-      color: var(--teal-light);
-    }
-
-    &[name='materials'] {
-      padding: 0 24px 14px 24px;
-    }
   }
 `

--- a/src/components/ProjectDetailsTab.js
+++ b/src/components/ProjectDetailsTab.js
@@ -12,7 +12,7 @@ export default function ProjectDetailsTab({ projectList, updateProjectData }) {
   const [isEditing, setEditing] = useState(false)
   const { id } = useParams()
   const projectData = projectList.find((project) => id === project.id)
-
+  console.log(projectData)
   const {
     projectName,
     pattern,
@@ -38,7 +38,7 @@ export default function ProjectDetailsTab({ projectList, updateProjectData }) {
             </>
           ) : (
             <div>
-              <p name="nextStepTitle">Next step:</p>
+              <p name="title">Next step:</p>
               <p name="nextStep">{nextStep}</p>
 
               {pattern ? <p name="pattern">{pattern}</p> : ''}
@@ -77,7 +77,6 @@ const StyledTab = styled.main`
   display: flex;
   flex-flow: column;
   align-items: center;
-  text-align: center;
   margin-top: -20px;
   padding: 0 30px 50px 30px;
   background: var(--copper-ultralight);
@@ -90,19 +89,15 @@ const StyledTab = styled.main`
     padding: 20px 0;
   }
 `
-const StyledProject = styled.li`
+const StyledProject = styled.div`
   position: relative;
-  list-style: none;
   width: 300px;
   border-radius: 10px;
   background: var(--copper-ultralight);
-  margin: 20px 20px 0 20px;
+  margin: 20px 0;
 
   p {
     font-weight: 200;
-    width: 260px;
-    overflow-wrap: break-word;
-    padding: 0 24px;
     color: var(--teal-light);
     font-size: 16px;
 
@@ -112,7 +107,7 @@ const StyledProject = styled.li`
       font-size: 20px;
     }
 
-    &[name='nextStepTitle'] {
+    &[name='title'] {
       margin-top: 10px;
       color: var(--teal-medium);
     }

--- a/src/components/ProjectDetailsTab.js
+++ b/src/components/ProjectDetailsTab.js
@@ -1,12 +1,18 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
+import editIcon from '../assets/editIcon.svg'
+import Button from './Button'
 import Headline from './Headline'
 import LogoHeader from './LogoHeader'
 import NavigationBar from './NavigationBar'
+import ProjectUpdateForm from './ProjectUpdateForm'
 
-export default function ProjectDetailsTab({ projectList }) {
+export default function ProjectDetailsTab({ projectList, updateProjectData }) {
+  const [isEditing, setEditing] = useState(false)
   const { id } = useParams()
+  const projectData = projectList.find((project) => id === project.id)
+
   const {
     projectName,
     pattern,
@@ -14,27 +20,53 @@ export default function ProjectDetailsTab({ projectList }) {
     nextStep,
     materialNeeds,
     materialsExisting,
-  } = projectList.find((project) => id === project.id)
-  console.log(projectName)
-  // const {
-  //   projectName,
-  //   pattern,
-  //   size,
-  //   nextStep,
-  //   materialNeeds,
-  //   materialsExisting,
-  // } = projectData
+  } = projectData
 
   return (
     <>
       <LogoHeader />
       <StyledTab>
         <Headline headlineText={projectName} textColor={'var(--teal-medium)'} />
-        <p>{pattern}</p>
-        <p>{size}</p>
-        <p>{nextStep}</p>
-        <p>{materialNeeds}</p>
-        <p>{materialsExisting}</p>
+        <StyledProject>
+          {isEditing ? (
+            <>
+              <ProjectUpdateForm
+                projectData={projectData}
+                updateProjectData={updateProjectData}
+                setEditing={setEditing}
+              />
+            </>
+          ) : (
+            <div>
+              <p name="nextStepTitle">Next step:</p>
+              <p name="nextStep">{nextStep}</p>
+
+              {pattern ? <p name="pattern">{pattern}</p> : ''}
+              {size ? <p name="size">Size: {size}</p> : ''}
+              {materialNeeds ? (
+                <p name="materials">
+                  Materials I need: <br></br>
+                  {materialNeeds}
+                </p>
+              ) : (
+                ''
+              )}
+              {materialsExisting ? (
+                <p name="materials">
+                  Materials I have: <br></br>
+                  {materialsExisting}
+                </p>
+              ) : (
+                ''
+              )}
+              <Button
+                size="30px"
+                icon={editIcon}
+                onClick={() => setEditing(true)}
+              />
+            </div>
+          )}
+        </StyledProject>
       </StyledTab>
       <NavigationBar />
     </>
@@ -56,5 +88,47 @@ const StyledTab = styled.main`
     color: var(--teal-medium);
     font-size: 16px;
     padding: 20px 0;
+  }
+`
+const StyledProject = styled.li`
+  position: relative;
+  list-style: none;
+  width: 300px;
+  border-radius: 10px;
+  background: var(--copper-ultralight);
+  margin: 20px 20px 0 20px;
+
+  p {
+    font-weight: 200;
+    width: 260px;
+    overflow-wrap: break-word;
+    padding: 0 24px;
+    color: var(--teal-light);
+    font-size: 16px;
+
+    &[name='projectName'] {
+      padding: 12px 24px 10px 24px;
+      color: var(--teal-dark);
+      font-size: 20px;
+    }
+
+    &[name='nextStepTitle'] {
+      margin-top: 10px;
+      color: var(--teal-medium);
+    }
+
+    &[name='nextStep'] {
+      color: var(--teal-light);
+    }
+
+    &[name='materials'] {
+      padding: 0 24px 14px 24px;
+    }
+  }
+
+  button {
+    position: absolute;
+    top: 16px;
+    right: 16px;
   }
 `

--- a/src/components/ProjectDetailsTab.js
+++ b/src/components/ProjectDetailsTab.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { useParams } from 'react-router-dom'
+import styled from 'styled-components'
+import Headline from './Headline'
+import LogoHeader from './LogoHeader'
+import NavigationBar from './NavigationBar'
+
+export default function ProjectDetailsTab({ projectList }) {
+  const { projectDetailPath } = useParams()
+  console.log(projectDetailPath)
+  const projectData = projectList.filter(
+    (project) => projectDetailPath === project.projectName
+  )
+  return (
+    <>
+      <LogoHeader />
+      <StyledTab>
+        <Headline
+          headlineText={'Project details'}
+          textColor={'var(--teal-medium)'}
+        />
+        <p className="question">{projectData.projectName}</p>
+      </StyledTab>
+      <NavigationBar />
+    </>
+  )
+}
+
+const StyledTab = styled.main`
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  text-align: center;
+  margin-top: -20px;
+  padding: 0 30px 50px 30px;
+  background: var(--copper-ultralight);
+  border-radius: 20px 20px 0 0;
+  box-shadow: 0 -1px 3px -1px rgba(0, 0, 0, 0.3);
+
+  p {
+    color: var(--teal-medium);
+    font-size: 16px;
+    padding: 20px 0;
+  }
+`

--- a/src/components/ProjectDetailsTab.js
+++ b/src/components/ProjectDetailsTab.js
@@ -6,11 +6,11 @@ import LogoHeader from './LogoHeader'
 import NavigationBar from './NavigationBar'
 
 export default function ProjectDetailsTab({ projectList }) {
-  const { projectDetailPath } = useParams()
-  console.log(projectDetailPath)
-  const projectData = projectList.filter(
-    (project) => projectDetailPath === project.projectName
-  )
+  const { id } = useParams()
+  const projectData = () => projectList.find((project) => id === project.id)
+  console.log(projectData)
+  // console.log(projectData.projectName)
+
   return (
     <>
       <LogoHeader />
@@ -19,7 +19,8 @@ export default function ProjectDetailsTab({ projectList }) {
           headlineText={'Project details'}
           textColor={'var(--teal-medium)'}
         />
-        <p className="question">{projectData.projectName}</p>
+        <p>nüscht</p>
+        {/* <p>{projectData.projectName}</p> */}
       </StyledTab>
       <NavigationBar />
     </>

--- a/src/components/ProjectDetailsTab.js
+++ b/src/components/ProjectDetailsTab.js
@@ -28,12 +28,6 @@ export default function ProjectDetailsTab({ projectList, updateProjectData }) {
       <LogoHeader />
       <StyledTab>
         <Headline headlineText={projectName} textColor={'var(--teal-medium)'} />
-        <Button
-          className="back-button"
-          size="11px"
-          icon={arrowLeft}
-          onClick={() => history.push('/projects')}
-        />
         <StyledProject>
           {isEditing ? (
             <>
@@ -46,7 +40,12 @@ export default function ProjectDetailsTab({ projectList, updateProjectData }) {
           ) : (
             <>
               <Button
-                className="edit-button"
+                size="11px"
+                icon={arrowLeft}
+                onClick={() => history.goBack()}
+                disabled={isEditing}
+              />
+              <Button
                 text="Edit"
                 size="30px"
                 icon={editIcon}
@@ -55,29 +54,18 @@ export default function ProjectDetailsTab({ projectList, updateProjectData }) {
               <p className="title">Next step:</p>
               <p className="entry">{nextStep}</p>
 
-              {pattern && (
-                <>
-                  <p className="title">Pattern:</p>
-                  <p className="entry">{pattern}</p>
-                </>
-              )}
-              {size && (
-                <>
-                  <p className="title">Size:</p>
-                  <p className="entry">{size}</p>
-                </>
-              )}
-              {materialNeeds && (
-                <>
-                  <p className="title">Materials I need:</p>
-                  <p className="entry">{materialNeeds}</p>
-                </>
-              )}
+              <p className="title">Pattern:</p>
+              {pattern && <p className="entry">{pattern}</p>}
+
+              <p className="title">Size:</p>
+              {size && <p className="entry">{size}</p>}
+
+              <p className="title">Materials I need:</p>
+              {materialNeeds && <p className="entry">{materialNeeds}</p>}
+
+              <p className="title">Materials I have:</p>
               {materialsExisting && (
-                <>
-                  <p className="title">Materials I have:</p>
-                  <p className="entry">{materialsExisting}</p>
-                </>
+                <p className="entry">{materialsExisting}</p>
               )}
             </>
           )}
@@ -89,7 +77,6 @@ export default function ProjectDetailsTab({ projectList, updateProjectData }) {
 }
 
 const StyledTab = styled.main`
-  position: relative;
   display: flex;
   flex-flow: column;
   align-items: center;
@@ -98,12 +85,6 @@ const StyledTab = styled.main`
   background: var(--copper-ultralight);
   border-radius: 20px 20px 0 0;
   box-shadow: 0 -1px 3px -1px rgba(0, 0, 0, 0.3);
-
-  > button {
-    position: absolute;
-    top: 22px;
-    left: 20px;
-  }
 `
 const StyledProject = styled.div`
   position: relative;
@@ -114,8 +95,14 @@ const StyledProject = styled.div`
 
   button {
     position: absolute;
+    margin: 0;
     top: -52px;
     right: -20px;
+  }
+
+  button:first-child {
+    top: -46px;
+    left: -10px;
   }
 
   p {
@@ -131,5 +118,11 @@ const StyledProject = styled.div`
     margin: 0 24px 0 24px;
     color: var(--teal-light);
     font-size: 16px;
+  }
+
+  .noEntryDisclaimer {
+    margin: 50px 0 50px 6px;
+    font-size: 10px;
+    color: var(--teal-ultralight);
   }
 `

--- a/src/components/ProjectDetailsTab.js
+++ b/src/components/ProjectDetailsTab.js
@@ -12,7 +12,6 @@ export default function ProjectDetailsTab({ projectList, updateProjectData }) {
   const [isEditing, setEditing] = useState(false)
   const { id } = useParams()
   const projectData = projectList.find((project) => id === project.id)
-  console.log(projectData)
   const {
     projectName,
     pattern,
@@ -38,32 +37,39 @@ export default function ProjectDetailsTab({ projectList, updateProjectData }) {
             </>
           ) : (
             <div>
-              <p name="title">Next step:</p>
-              <p name="nextStep">{nextStep}</p>
-
-              {pattern ? <p name="pattern">{pattern}</p> : ''}
-              {size ? <p name="size">Size: {size}</p> : ''}
-              {materialNeeds ? (
-                <p name="materials">
-                  Materials I need: <br></br>
-                  {materialNeeds}
-                </p>
-              ) : (
-                ''
-              )}
-              {materialsExisting ? (
-                <p name="materials">
-                  Materials I have: <br></br>
-                  {materialsExisting}
-                </p>
-              ) : (
-                ''
-              )}
               <Button
+                text="Edit"
                 size="30px"
                 icon={editIcon}
                 onClick={() => setEditing(true)}
               />
+              <p name="title">Next step:</p>
+              <p name="nextStep">{nextStep}</p>
+
+              {pattern && (
+                <>
+                  <p name="title">Pattern:</p>
+                  <p name="pattern">{pattern}</p>
+                </>
+              )}
+              {size && (
+                <>
+                  <p name="title">Size:</p>
+                  <p name="size">{size}</p>
+                </>
+              )}
+              {materialNeeds && (
+                <>
+                  <p name="title">Materials I need:</p>
+                  <p name="materials">{materialNeeds}</p>
+                </>
+              )}
+              {materialsExisting && (
+                <>
+                  <p name="title">Materials I have:</p>
+                  <p name="materials">{materialsExisting}</p>
+                </>
+              )}
             </div>
           )}
         </StyledProject>
@@ -86,7 +92,6 @@ const StyledTab = styled.main`
   p {
     color: var(--teal-medium);
     font-size: 16px;
-    padding: 20px 0;
   }
 `
 const StyledProject = styled.div`
@@ -95,6 +100,12 @@ const StyledProject = styled.div`
   border-radius: 10px;
   background: var(--copper-ultralight);
   margin: 20px 0;
+
+  button {
+    position: absolute;
+    top: -16px;
+    right: -16px;
+  }
 
   p {
     font-weight: 200;
@@ -119,11 +130,5 @@ const StyledProject = styled.div`
     &[name='materials'] {
       padding: 0 24px 14px 24px;
     }
-  }
-
-  button {
-    position: absolute;
-    top: 16px;
-    right: 16px;
   }
 `

--- a/src/components/ProjectDetailsTab.js
+++ b/src/components/ProjectDetailsTab.js
@@ -114,8 +114,8 @@ const StyledProject = styled.div`
 
   button {
     position: absolute;
-    top: -6px;
-    right: -16px;
+    top: -52px;
+    right: -20px;
   }
 
   p {

--- a/src/components/ProjectDetailsTab.stories.js
+++ b/src/components/ProjectDetailsTab.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ProjectDetailsTab from './ProjectDetailsTab'
-import { array, object, withKnobs } from '@storybook/addon-knobs/react'
+import { object, withKnobs } from '@storybook/addon-knobs/react'
 
 export default {
   title: 'Project Details Tab',
@@ -9,7 +9,7 @@ export default {
 }
 
 const projectEntry = {
-  projectName: 'Summer dress with sleeves',
+  projectName: 'Summer dress',
   pattern: 'Pinterest',
   size: '36',
   nextStep: 'cut fabric and lining, buy button, zipper and tape',

--- a/src/components/ProjectDetailsTab.stories.js
+++ b/src/components/ProjectDetailsTab.stories.js
@@ -1,9 +1,20 @@
 import React from 'react'
 import ProjectDetailsTab from './ProjectDetailsTab'
+import { array, object, withKnobs } from '@storybook/addon-knobs/react'
 
 export default {
   title: 'Project Details Tab',
   component: ProjectDetailsTab,
+  decorators: [withKnobs],
 }
 
-export const projectDetailsTab = () => <ProjectDetailsTab />
+const projectEntry = {
+  projectName: 'Summer dress with sleeves',
+  pattern: 'Pinterest',
+  size: '36',
+  nextStep: 'cut fabric and lining, buy button, zipper and tape',
+}
+
+export const projectDetailsTab = () => (
+  <ProjectDetailsTab projectList={[object('mock up entry', projectEntry)]} />
+)

--- a/src/components/ProjectDetailsTab.stories.js
+++ b/src/components/ProjectDetailsTab.stories.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import ProjectDetailsTab from './ProjectDetailsTab'
+
+export default {
+  title: 'Project Details Tab',
+  component: ProjectDetailsTab,
+}
+
+export const projectDetailsTab = () => <ProjectDetailsTab />

--- a/src/components/ProjectList.js
+++ b/src/components/ProjectList.js
@@ -14,16 +14,18 @@ export default function ProjectList({ projectList }) {
           headlineText="Projects"
           textColor={'var(--copper-ultralight)'}
         />
-        {projectList.length <= 0 && (
-          <p className="noProjectsYet">
-            Click the button below to add your first project!
-          </p>
-        )}
-        <StyledProjectList>
-          {projectList.map((projectData) => (
-            <ProjectListItem key={projectData.id} projectData={projectData} />
-          ))}
-        </StyledProjectList>
+        <div>
+          {projectList.length <= 0 && (
+            <p className="noProjectsYet">
+              Click the button below to add your first project!
+            </p>
+          )}
+          <StyledProjectList>
+            {projectList.map((projectData) => (
+              <ProjectListItem key={projectData.id} projectData={projectData} />
+            ))}
+          </StyledProjectList>
+        </div>
       </StyledTab>
       <NavigationBar />
     </>
@@ -47,6 +49,11 @@ const StyledTab = styled.main`
     text-align: center;
     padding-top: 200px;
   }
+
+  > div {
+    height: 480px;
+    overflow: scroll;
+  }
 `
 
 const StyledProjectList = styled.ul`
@@ -55,6 +62,6 @@ const StyledProjectList = styled.ul`
   align-items: center;
 
   a:first-child {
-    margin-bottom: 80px;
+    margin-bottom: 35px;
   }
 `

--- a/src/components/ProjectList.js
+++ b/src/components/ProjectList.js
@@ -58,7 +58,7 @@ const StyledProjectList = styled.ul`
   flex-direction: column-reverse;
   align-items: center;
 
-  li:first-child {
+  a:first-child {
     margin-bottom: 80px;
   }
 `

--- a/src/components/ProjectList.js
+++ b/src/components/ProjectList.js
@@ -5,7 +5,7 @@ import LogoHeader from './LogoHeader'
 import NavigationBar from './NavigationBar'
 import ProjectListItem from './ProjectListItem'
 
-export default function ProjectList({ projectList, updateProjectData }) {
+export default function ProjectList({ projectList }) {
   return (
     <>
       <LogoHeader />
@@ -21,11 +21,7 @@ export default function ProjectList({ projectList, updateProjectData }) {
         )}
         <StyledProjectList>
           {projectList.map((projectData) => (
-            <ProjectListItem
-              key={projectData.id}
-              projectData={projectData}
-              updateProjectData={updateProjectData}
-            />
+            <ProjectListItem key={projectData.id} projectData={projectData} />
           ))}
         </StyledProjectList>
       </StyledTab>

--- a/src/components/ProjectListItem.js
+++ b/src/components/ProjectListItem.js
@@ -6,7 +6,6 @@ import Button from './Button'
 import ProjectUpdateForm from './ProjectUpdateForm'
 
 export default function ProjectListItem({ projectData, updateProjectData }) {
-  // const { url } = useRouteMatch()
   const [isEditing, setEditing] = useState(false)
   const {
     id,
@@ -19,11 +18,7 @@ export default function ProjectListItem({ projectData, updateProjectData }) {
   } = projectData
 
   return (
-<<<<<<< HEAD
-    <Link to={`projects/${projectName}/${id}`}>
-=======
-    <Link to={`/projects/${projectName}`}>
->>>>>>> d99f8e67c76ec9c73f04d88e7cbd606c04ff95ce
+    <StyledLink to={`projects/${projectName}/${id}`}>
       <StyledProject>
         {isEditing ? (
           <>
@@ -63,7 +58,7 @@ export default function ProjectListItem({ projectData, updateProjectData }) {
           </div>
         )}
       </StyledProject>
-    </Link>
+    </StyledLink>
   )
 }
 
@@ -71,7 +66,6 @@ const StyledProject = styled.li`
   position: relative;
   list-style: none;
   width: 300px;
-  height: 100%;
   border-radius: 10px;
   background: var(--copper-ultralight);
   margin: 20px 20px 0 20px;
@@ -106,4 +100,7 @@ const StyledProject = styled.li`
     top: 16px;
     right: 16px;
   }
+`
+const StyledLink = styled(Link)`
+  text-decoration: none;
 `

--- a/src/components/ProjectListItem.js
+++ b/src/components/ProjectListItem.js
@@ -6,6 +6,7 @@ import Button from './Button'
 import ProjectUpdateForm from './ProjectUpdateForm'
 
 export default function ProjectListItem({ projectData, updateProjectData }) {
+  // const { url } = useRouteMatch()
   const [isEditing, setEditing] = useState(false)
   const {
     id,
@@ -18,7 +19,11 @@ export default function ProjectListItem({ projectData, updateProjectData }) {
   } = projectData
 
   return (
+<<<<<<< HEAD
     <Link to={`projects/${projectName}/${id}`}>
+=======
+    <Link to={`/projects/${projectName}`}>
+>>>>>>> d99f8e67c76ec9c73f04d88e7cbd606c04ff95ce
       <StyledProject>
         {isEditing ? (
           <>

--- a/src/components/ProjectListItem.js
+++ b/src/components/ProjectListItem.js
@@ -1,62 +1,16 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
-import editIcon from '../assets/editIcon.svg'
-import Button from './Button'
-import ProjectUpdateForm from './ProjectUpdateForm'
 
-export default function ProjectListItem({ projectData, updateProjectData }) {
-  const [isEditing, setEditing] = useState(false)
-  const {
-    id,
-    projectName,
-    pattern,
-    size,
-    nextStep,
-    materialNeeds,
-    materialsExisting,
-  } = projectData
+export default function ProjectListItem({ projectData }) {
+  const { id, projectName, nextStep } = projectData
 
   return (
-    <StyledLink to={`projects/${projectName}/${id}`}>
+    <StyledLink to={`/projects/${projectName}/${id}`}>
       <StyledProject>
-        {isEditing ? (
-          <>
-            <ProjectUpdateForm
-              projectData={projectData}
-              updateProjectData={updateProjectData}
-              setEditing={setEditing}
-            />
-          </>
-        ) : (
-          <div>
-            <p name="projectName">{projectName}</p>
-            {pattern ? <p name="pattern">{pattern}</p> : ''}
-            {size ? <p name="size">Size: {size}</p> : ''}
-            <p name="nextStep">Next step: {nextStep}</p>
-            {materialNeeds ? (
-              <p name="materials">
-                Materials I need: <br></br>
-                {materialNeeds}
-              </p>
-            ) : (
-              ''
-            )}
-            {materialsExisting ? (
-              <p name="materials">
-                Materials I have: <br></br>
-                {materialsExisting}
-              </p>
-            ) : (
-              ''
-            )}
-            <Button
-              size="30px"
-              icon={editIcon}
-              onClick={() => setEditing(true)}
-            />
-          </div>
-        )}
+        <p name="projectName">{projectName}</p>
+        <p name="nextStepTitle">Next step:</p>
+        <p name="nextStep">{nextStep}</p>
       </StyledProject>
     </StyledLink>
   )
@@ -69,36 +23,25 @@ const StyledProject = styled.li`
   border-radius: 10px;
   background: var(--copper-ultralight);
   margin: 20px 20px 0 20px;
+  padding: 16px 20px;
 
   p {
     font-weight: 200;
-    width: 260px;
-    overflow-wrap: break-word;
-    padding: 0 24px;
-    color: var(--teal-light);
     font-size: 16px;
 
     &[name='projectName'] {
-      padding: 12px 24px 10px 24px;
       color: var(--teal-dark);
       font-size: 20px;
     }
 
-    &[name='nextStep'] {
-      padding: 12px 24px 14px 24px;
+    &[name='nextStepTitle'] {
+      margin-top: 10px;
       color: var(--teal-medium);
-      font-size: 16px;
     }
 
-    &[name='materials'] {
-      padding: 0 24px 14px 24px;
+    &[name='nextStep'] {
+      color: var(--teal-light);
     }
-  }
-
-  button {
-    position: absolute;
-    top: 16px;
-    right: 16px;
   }
 `
 const StyledLink = styled(Link)`

--- a/src/components/ProjectListItem.js
+++ b/src/components/ProjectListItem.js
@@ -1,10 +1,12 @@
 import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import editIcon from '../assets/editIcon.svg'
 import Button from './Button'
 import ProjectUpdateForm from './ProjectUpdateForm'
 
 export default function ProjectListItem({ projectData, updateProjectData }) {
+  // const { url } = useRouteMatch()
   const [isEditing, setEditing] = useState(false)
   const {
     projectName,
@@ -16,45 +18,47 @@ export default function ProjectListItem({ projectData, updateProjectData }) {
   } = projectData
 
   return (
-    <StyledProject>
-      {isEditing ? (
-        <>
-          <ProjectUpdateForm
-            projectData={projectData}
-            updateProjectData={updateProjectData}
-            setEditing={setEditing}
-          />
-        </>
-      ) : (
-        <div>
-          <p name="projectName">{projectName}</p>
-          {pattern ? <p name="pattern">{pattern}</p> : ''}
-          {size ? <p name="size">Size: {size}</p> : ''}
-          <p name="nextStep">Next step: {nextStep}</p>
-          {materialNeeds ? (
-            <p name="materials">
-              Materials I need: <br></br>
-              {materialNeeds}
-            </p>
-          ) : (
-            ''
-          )}
-          {materialsExisting ? (
-            <p name="materials">
-              Materials I have: <br></br>
-              {materialsExisting}
-            </p>
-          ) : (
-            ''
-          )}
-          <Button
-            size="30px"
-            icon={editIcon}
-            onClick={() => setEditing(true)}
-          />
-        </div>
-      )}
-    </StyledProject>
+    <Link to={`/projects/${projectName}`}>
+      <StyledProject>
+        {isEditing ? (
+          <>
+            <ProjectUpdateForm
+              projectData={projectData}
+              updateProjectData={updateProjectData}
+              setEditing={setEditing}
+            />
+          </>
+        ) : (
+          <div>
+            <p name="projectName">{projectName}</p>
+            {pattern ? <p name="pattern">{pattern}</p> : ''}
+            {size ? <p name="size">Size: {size}</p> : ''}
+            <p name="nextStep">Next step: {nextStep}</p>
+            {materialNeeds ? (
+              <p name="materials">
+                Materials I need: <br></br>
+                {materialNeeds}
+              </p>
+            ) : (
+              ''
+            )}
+            {materialsExisting ? (
+              <p name="materials">
+                Materials I have: <br></br>
+                {materialsExisting}
+              </p>
+            ) : (
+              ''
+            )}
+            <Button
+              size="30px"
+              icon={editIcon}
+              onClick={() => setEditing(true)}
+            />
+          </div>
+        )}
+      </StyledProject>
+    </Link>
   )
 }
 

--- a/src/components/ProjectListItem.js
+++ b/src/components/ProjectListItem.js
@@ -1,12 +1,13 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useRouteMatch } from 'react-router-dom'
 import styled from 'styled-components'
 
 export default function ProjectListItem({ projectData }) {
+  const { url } = useRouteMatch()
   const { id, projectName, nextStep } = projectData
 
   return (
-    <StyledLink to={`/projects/${projectName}/${id}`}>
+    <StyledLink to={`${url}/${projectName}/${id}`}>
       <StyledProject>
         <p name="projectName">{projectName}</p>
         <p name="nextStepTitle">Next step:</p>

--- a/src/components/ProjectListItem.js
+++ b/src/components/ProjectListItem.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Link, useRouteMatch } from 'react-router-dom'
 import styled from 'styled-components'
+import arrowRight from '../assets/arrowRight.svg'
 
 export default function ProjectListItem({ projectData }) {
   const { url } = useRouteMatch()
@@ -12,6 +13,7 @@ export default function ProjectListItem({ projectData }) {
         <p name="projectName">{projectName}</p>
         <p name="nextStepTitle">Next step:</p>
         <p name="nextStep">{nextStep}</p>
+        <img src={arrowRight} alt="" />
       </StyledProject>
     </StyledLink>
   )
@@ -43,6 +45,15 @@ const StyledProject = styled.li`
     &[name='nextStep'] {
       color: var(--teal-light);
     }
+  }
+
+  img {
+    position: absolute;
+    width: 11px;
+    margin-top: -12px;
+    top: 50%;
+    right: 10px;
+    opacity: 0.7;
   }
 `
 const StyledLink = styled(Link)`

--- a/src/components/ProjectListItem.js
+++ b/src/components/ProjectListItem.js
@@ -6,9 +6,9 @@ import Button from './Button'
 import ProjectUpdateForm from './ProjectUpdateForm'
 
 export default function ProjectListItem({ projectData, updateProjectData }) {
-  // const { url } = useRouteMatch()
   const [isEditing, setEditing] = useState(false)
   const {
+    id,
     projectName,
     pattern,
     size,
@@ -18,7 +18,7 @@ export default function ProjectListItem({ projectData, updateProjectData }) {
   } = projectData
 
   return (
-    <Link to={`/projects/${projectName}`}>
+    <Link to={`projects/${projectName}/${id}`}>
       <StyledProject>
         {isEditing ? (
           <>

--- a/src/components/ProjectUpdateForm.js
+++ b/src/components/ProjectUpdateForm.js
@@ -22,7 +22,18 @@ export default function ProjectUpdateForm({
 
   return (
     <StyledForm onSubmit={handleSubmit(handleNewData)}>
+      <InputTextarea
+        labelText="Next step:"
+        name="nextStep"
+        onChange={handleChange}
+        registerFn={register}
+        error={errors.nextStep}
+        errorMessageMax="Don't make it too long"
+        errorMessageRequired="Keep track of the next step!"
+      />
+
       <InputField
+        labelText="Project Name:"
         name="projectName"
         onChange={handleChange}
         registerFn={register}
@@ -32,6 +43,7 @@ export default function ProjectUpdateForm({
       />
 
       <InputField
+        labelText="Pattern:"
         name="pattern"
         placeholderText="Did you find a pattern?"
         onChange={handleChange}
@@ -41,6 +53,7 @@ export default function ProjectUpdateForm({
       />
 
       <InputField
+        labelText="Size:"
         name="size"
         placeholderText="What's the size?"
         onChange={handleChange}
@@ -49,16 +62,8 @@ export default function ProjectUpdateForm({
         errorMessageMax="The text is too long..."
       />
 
-      <InputField
-        name="nextStep"
-        onChange={handleChange}
-        registerFn={register}
-        error={errors.nextStep}
-        errorMessageMax="Don't make it too long"
-        errorMessageRequired="Keep track of the next step!"
-      />
-
       <InputTextarea
+        labelText="Materials I need:"
         name="materialNeeds"
         placeholderText="What materials do you need? Separate materials with a comma."
         onChange={handleChange}
@@ -68,6 +73,7 @@ export default function ProjectUpdateForm({
       />
 
       <InputTextarea
+        labelText="Materials I have:"
         name="materialsExisting"
         placeholderText="What materials do you already have? Separate materials with a comma."
         onChange={handleChange}
@@ -95,57 +101,19 @@ export default function ProjectUpdateForm({
 }
 
 const StyledForm = styled.form`
+  height: 438px;
+  overflow: scroll;
+
   label {
     display: block;
     padding: 0;
+    margin: 20px 0 0 6px;
   }
 
-  /* error message div */
-  label > div {
-    padding: 0 0 5px 15px;
-  }
-
-  input {
-    font-weight: 200;
-    width: 230px;
-    height: 100%;
-    border-radius: 4px;
-    margin: 2px 0 2px 15px;
-    color: var(--teal-ultralight);
-    font-size: 16px;
-
-    &[name='projectName'] {
-      margin: 5px 0 2px 15px;
-      padding: 7px 10px 5px 10px;
-      font-size: 20px;
-      color: var(--teal-light);
-    }
-
-    &[name='nextStep'] {
-      margin: 2px 0 5px 15px;
-      padding: 8px 10px 10px 10px;
-      color: var(--teal-medium);
-    }
-  }
-
+  input,
   textarea {
-    width: 230px;
-    height: 100px;
-    border-radius: 4px;
-    margin: 0 0 10px 15px;
-    padding: 0 10px;
-    color: var(--teal-ultralight);
-    font-size: 16px;
-
-    :focus {
-      outline: none;
-      box-shadow: 0 0 0 1pt var(--teal-ultralight);
-    }
-  }
-
-  button {
-    position: absolute;
-    top: 16px;
-    right: 16px;
+    font-weight: 200;
+    color: var(--teal-light);
+    background-color: white;
   }
 `

--- a/src/components/ProjectUpdateForm.js
+++ b/src/components/ProjectUpdateForm.js
@@ -76,7 +76,7 @@ export default function ProjectUpdateForm({
         errorMessageMax="The text is too long...?"
       />
 
-      <Button size="30px" icon={saveIcon} />
+      <Button text="Save" size="30px" icon={saveIcon} />
     </StyledForm>
   )
 

--- a/src/components/ShoppingList.js
+++ b/src/components/ShoppingList.js
@@ -16,20 +16,22 @@ export default function ShoppingList({ projectList }) {
           headlineText="Shopping list"
           textColor={'var(--copper-ultralight)'}
         />
-        {materialsNeeded.length <= 0 ? (
-          <p className="noMaterialNeedsYet">
-            Create a material list in one of your projects first!
-          </p>
-        ) : (
-          <StyledShoppingList>
-            {materialsNeeded.map((projectData) => (
-              <ShoppingListItem
-                key={projectData.id}
-                projectData={projectData}
-              />
-            ))}
-          </StyledShoppingList>
-        )}
+        <div>
+          {materialsNeeded.length <= 0 ? (
+            <p className="noMaterialNeedsYet">
+              Create a material list in one of your projects first!
+            </p>
+          ) : (
+            <StyledShoppingList>
+              {materialsNeeded.map((projectData) => (
+                <ShoppingListItem
+                  key={projectData.id}
+                  projectData={projectData}
+                />
+              ))}
+            </StyledShoppingList>
+          )}
+        </div>
       </StyledTab>
       <NavigationBar />
     </>
@@ -53,6 +55,11 @@ const StyledTab = styled.main`
     text-align: center;
     padding-top: 200px;
   }
+
+  > div {
+    height: 480px;
+    overflow: scroll;
+  }
 `
 
 const StyledShoppingList = styled.ul`
@@ -60,7 +67,7 @@ const StyledShoppingList = styled.ul`
   flex-direction: column-reverse;
   align-items: center;
 
-  li:first-child {
-    margin-bottom: 80px;
+  a:first-child {
+    margin-bottom: 35px;
   }
 `

--- a/src/components/ShoppingListItem.js
+++ b/src/components/ShoppingListItem.js
@@ -1,16 +1,21 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components'
+import arrowRight from '../assets/arrowRight.svg'
 
 export default function ShoppingListItem({ projectData }) {
-  const { projectName, materialNeeds } = projectData
+  const { id, projectName, materialNeeds } = projectData
 
   return (
     <>
       {materialNeeds ? (
-        <StyledProject>
-          <p name="materials">{materialNeeds}</p>
-          <p name="projectName">for project: {projectName}</p>
-        </StyledProject>
+        <StyledLink to={`/projects/${projectName}/${id}`}>
+          <StyledProject>
+            <p name="materials">{materialNeeds}</p>
+            <p name="projectName">for project: {projectName}</p>
+            <img src={arrowRight} alt="" />
+          </StyledProject>
+        </StyledLink>
       ) : (
         ''
       )}
@@ -22,7 +27,6 @@ const StyledProject = styled.li`
   position: relative;
   list-style: none;
   width: 300px;
-  height: 100%;
   border-radius: 10px;
   background: var(--copper-ultralight);
   margin: 20px 20px 0 20px;
@@ -45,4 +49,15 @@ const StyledProject = styled.li`
       padding: 0 24px 14px 24px;
     }
   }
+
+  img {
+    position: absolute;
+    width: 9px;
+    bottom: 13px;
+    right: 10px;
+    opacity: 0.7;
+  }
+`
+const StyledLink = styled(Link)`
+  text-decoration: none;
 `

--- a/src/components/hooks/useLocalStorageState.js
+++ b/src/components/hooks/useLocalStorageState.js
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+import {
+  getFromLocalStorage,
+  saveToLocalStorage,
+} from '../utils/handleLocalStorage'
+
+export const useLocalStorageState = (key) => {
+  const [value, setValue] = useState(getFromLocalStorage(key) || [])
+
+  useEffect(() => {
+    saveToLocalStorage(key, value)
+  }, [value, key])
+  return [value, setValue]
+}

--- a/src/components/utils/handleLocalStorage.js
+++ b/src/components/utils/handleLocalStorage.js
@@ -3,5 +3,9 @@ export function saveToLocalStorage(key, data) {
 }
 
 export function getFromLocalStorage(key) {
-  return JSON.parse(localStorage.getItem(key))
+  try {
+    return JSON.parse(localStorage.getItem(key))
+  } catch (error) {
+    console.log(error)
+  }
 }

--- a/src/components/utils/initialProjectListState.json
+++ b/src/components/utils/initialProjectListState.json
@@ -1,6 +1,6 @@
 [
   {
-    "projectName": "Summer dress with sleeves",
+    "projectName": "Summer Dress Liberty",
     "pattern": "Pinterest",
     "size": "36",
     "nextStep": "cut fabric and lining, buy button, zipper and tape",

--- a/src/components/utils/projectSchema.js
+++ b/src/components/utils/projectSchema.js
@@ -1,7 +1,7 @@
 import * as yup from 'yup'
 
 export const projectSchema = yup.object().shape({
-  projectName: yup.string().max(25).required(),
+  projectName: yup.string().max(20).required(),
   nextStep: yup.string().max(50).required(),
   pattern: yup.string().max(35),
   size: yup.string().max(25),


### PR DESCRIPTION
Add project detail pages, move update form to details page and only display name and status on project list page. Update form will be restyled in the next story, also the max length for the project name entry will be reduced in the next step. 